### PR TITLE
Work on <relevant-academic-terms>

### DIFF
--- a/response-example.xml
+++ b/response-example.xml
@@ -106,5 +106,16 @@
         <unit-id>fsat.no</unit-id>
         <unit-id>matnat.uio.no</unit-id>
         <unit-id>hf.uio.no</unit-id>
+
+        <!-- WRTODO: This needs explanation. -->
+        <relevant-academic-terms>
+            <trm:academic-term>
+                <trm:academic-year-id>2010/2011</trm:academic-year-id>
+                <trm:display-name xml:lang="en">Winter Trimester 2010/2011</trm:display-name>
+                <trm:display-name xml:lang="pl">Drugi Trymestr 2010/2011</trm:display-name>
+                <trm:start-date>2010-12-01</trm:start-date>
+                <trm:end-date>2011-03-15</trm:end-date>
+            </trm:academic-term>
+        </relevant-academic-terms>
     </hei>
 </institutions-response>

--- a/response.xsd
+++ b/response.xsd
@@ -383,6 +383,19 @@
                                     </xs:documentation>
                                 </xs:annotation>
                             </xs:element>
+                            <xs:element name="relevant-academic-terms" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The list of academic terms which... WRTODO: How do I document this? I didn't
+                                        understand WHICH academic terms we want here, exactly.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element ref="trm:academic-term" minOccurs="0" maxOccurs="unbounded"/>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>


### PR DESCRIPTION
Since I am not 100% sure which academic terms are supposed to be included in the Institutions API response, I have pushed them to a separate branch until I can document them properly.

If I remember correctly, this feature was endorsed by @janinamincer-daszkiewicz and @kaiqu. Could you please explain once more why we might need academic terms in Institutions API?
